### PR TITLE
Add Keyboard Navigation

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcbaselines/SpanGridTests.xcbaseline/434BCB99-6C82-42A5-9697-196D5335205E.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/SpanGridTests.xcbaseline/434BCB99-6C82-42A5-9697-196D5335205E.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>2.250000</real>
+					<real>0.135000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/SpanGridTests.xcbaseline/434BCB99-6C82-42A5-9697-196D5335205E.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/SpanGridTests.xcbaseline/434BCB99-6C82-42A5-9697-196D5335205E.plist
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>SpanGridKeyboardNavigationTests</key>
+		<dict>
+			<key>testMonkeyNavigationAndPerformance()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>2.250000</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+		<key>SpanGridPerformanceTests</key>
+		<dict>
+			<key>testCreateSpanView()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.001930</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testDynamicColumnStrategy()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.001660</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testInitialisation()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.006300</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testSpanIndexCache()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.000849</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/SpanGridTests.xcbaseline/Info.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/SpanGridTests.xcbaseline/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>434BCB99-6C82-42A5-9697-196D5335205E</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>400</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>8-Core Intel Core i9</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2300</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>16</integer>
+				<key>modelCode</key>
+				<string>MacBookPro16,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPad13,10</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/SpanGrid.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/SpanGrid.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SpanGrid"
+               BuildableName = "SpanGrid"
+               BlueprintName = "SpanGrid"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SpanGridTests"
+               BuildableName = "SpanGridTests"
+               BlueprintName = "SpanGridTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SpanGridTests"
+               BuildableName = "SpanGridTests"
+               BlueprintName = "SpanGridTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "SpanGrid"
+            BuildableName = "SpanGrid"
+            BlueprintName = "SpanGrid"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ Options include:
 * `dynamic` (default) provides an opinionated column structure which adapts to the size of the device and includes some accessibility changes.
 * `custom` allows you to provide your own implementation. This will provide you with the current width of the grid. 
 
+### Keyboard Navigation (Opt-in)
+
+This allows users to navigate through rows/items using an attached keyboard (iPadOS).
+
+> Due to an Apple limitation, we currently use WASD keys rather than arrow keys. We hope this'll change in the future.
+
+When instantiating the SpanGrid, you can pass through keyboard navigation options which includes turning on the feature,
+as well as turning on/off keyboard discoverability and the localized strings shown to users (default English only strings 
+are provided).
+
 ## Notes
 
 I do not pledge to be an expert in SwiftUI, so there may be many issues with the current implementation. I have tested it

--- a/Sources/Business Logic/SpanGridDynamicColumnSizeStrategy.swift
+++ b/Sources/Business Logic/SpanGridDynamicColumnSizeStrategy.swift
@@ -7,7 +7,6 @@
 import SwiftUI
 
 public struct SpanGridDynamicColumnSizeStrategy {
-    
     public struct Configuration {
         let maximumGridWidth: CGFloat
         let maximumGridWidthAccessibility: CGFloat

--- a/Sources/Business Logic/SpanGridKeyboardNavigation.swift
+++ b/Sources/Business Logic/SpanGridKeyboardNavigation.swift
@@ -51,7 +51,11 @@ class SpanGridKeyboardNavigation<Content: View, Data: Identifiable & SpanGridSiz
             let originalSpanIndex = grid.spanIndexCalculator.getSpanIndex(forItemWithOffset: currentItem, columnCount: columnCount)
             let spanIndexOffset = mutableSpanIndex - originalSpanIndex
             
-            let spanPrefix = grid.calculateCellPrefix(spanSize: spanSize, columnCount: columnCount, spanIndex: mutableSpanIndex)
+            let spanPrefix = grid.calculateCellPrefix(
+                spanSize: spanSize,
+                columnCount: columnCount,
+                spanIndex: direction == .left ? mutableSpanIndex : originalSpanIndex
+            )
             
             switch direction {
             case .left where spanSize == 1:
@@ -79,6 +83,7 @@ class SpanGridKeyboardNavigation<Content: View, Data: Identifiable & SpanGridSiz
             }
             
             guard let newItem = grid.spanIndexCalculator.reverseLookup[mutableSpanIndex] else {
+                print("[SpanGridKeyboardNavigation] Unknown Span Index: \(mutableSpanIndex)")
                 return
             }
             

--- a/Sources/Business Logic/SpanGridKeyboardNavigation.swift
+++ b/Sources/Business Logic/SpanGridKeyboardNavigation.swift
@@ -51,7 +51,6 @@ class SpanGridKeyboardNavigation<Content: View, Data: Identifiable & SpanGridSiz
             let originalSpanIndex = grid.spanIndexCalculator.getSpanIndex(forItemWithOffset: currentItem, columnCount: columnCount)
             let spanIndexOffset = mutableSpanIndex - originalSpanIndex
             
-            #warning("Bug Fix: We need to take into account cell prefix size for whitespace")
             let spanPrefix = grid.calculateCellPrefix(spanSize: spanSize, columnCount: columnCount, spanIndex: mutableSpanIndex)
             
             switch direction {
@@ -68,11 +67,11 @@ class SpanGridKeyboardNavigation<Content: View, Data: Identifiable & SpanGridSiz
             case .up:
                 repeat {
                     mutableSpanIndex -= columnCount
-                } while (strongSelf.isInvalidCell(spanIndex: mutableSpanIndex, columnCount: columnCount, grid: grid))
+                } while strongSelf.isInvalidCell(spanIndex: mutableSpanIndex, columnCount: columnCount, grid: grid)
             case .down:
                 repeat {
                     mutableSpanIndex += columnCount
-                } while (strongSelf.isInvalidCell(spanIndex: mutableSpanIndex, columnCount: columnCount, grid: grid))
+                } while strongSelf.isInvalidCell(spanIndex: mutableSpanIndex, columnCount: columnCount, grid: grid)
             }
             
             if mutableSpanIndex < 0 {

--- a/Sources/Business Logic/SpanGridKeyboardNavigation.swift
+++ b/Sources/Business Logic/SpanGridKeyboardNavigation.swift
@@ -1,0 +1,103 @@
+//
+// SpanGridKeyboardNavigation.swift
+//
+// Copyright 2021 • James Sherlock
+//
+
+import SwiftUI
+
+class SpanGridKeyboardNavigation<Content: View, Data: Identifiable & SpanGridSizeInfoProvider>: ObservableObject {
+    @Published var currentItem: Int? = nil
+    
+    var grid: SpanGrid<Content, Data>?
+    private var currentSpanIndex: Int = 0
+    
+    func setCurrentItem(newValue: Int) -> Bool {
+        guard let grid = grid else {
+            // Lost grid reference
+            return false
+        }
+        
+        guard (0 ..< grid.data.count).contains(newValue) else {
+            // Out of bounds
+            return false
+        }
+        
+        guard newValue != currentItem else {
+            // No change in value
+            return false
+        }
+        
+        currentItem = newValue
+        return true
+    }
+    
+    func processDirection(_ columnCount: Int) -> (SpanGridKeyboardNavigationShortcuts.Direction) -> Void {
+        { [weak self] direction in
+            guard let strongSelf = self, let grid = strongSelf.grid else {
+                return
+            }
+            
+            // If this is the first time they've pressed a shortcut, then we start them in the top left.
+            if strongSelf.currentItem == nil {
+                _ = strongSelf.setCurrentItem(newValue: 0)
+                return
+            }
+            
+            let currentItem = strongSelf.currentItem ?? 0
+            var mutableSpanIndex = strongSelf.currentSpanIndex
+            let spanSize = grid.data[currentItem].data.layoutSize.spanSize(columnCount: columnCount)
+            
+            let originalSpanIndex = grid.spanIndexCalculator.getSpanIndex(forItemWithOffset: currentItem, columnCount: columnCount)
+            let spanIndexOffset = mutableSpanIndex - originalSpanIndex
+            
+            #warning("Bug Fix: We need to take into account cell prefix size for whitespace")
+            // let spanPrefix = grid.calculateCellPrefix(spanSize: spanSize, columnCount: columnCount, spanIndex: mutableSpanIndex)
+            
+            switch direction {
+            case .left where spanSize == 1:
+                mutableSpanIndex -= spanSize
+            case .left:
+                mutableSpanIndex -= spanSize - (spanSize - spanIndexOffset) + 1
+                
+            case .right where spanSize == 1:
+                mutableSpanIndex += spanSize
+            case .right:
+                mutableSpanIndex += spanSize - spanIndexOffset
+                
+            case .up:
+                mutableSpanIndex -= columnCount
+            case .down:
+                mutableSpanIndex += columnCount
+            }
+            
+            if mutableSpanIndex < 0 {
+                return
+            }
+            
+            #warning("Optimisation: Cache a dictionary of spanIndex: itemIndex for the full range of data?")
+            let spanCache = grid.spanIndexCalculator.cache.sorted(by: { $0.key < $1.key })
+            var lastItem: Int?
+            
+            for item in spanCache {
+                if item.value >= mutableSpanIndex {
+                    let diff = item.value - mutableSpanIndex
+                    
+                    if diff > 0 {
+                        if strongSelf.setCurrentItem(newValue: lastItem ?? item.key) {
+                            strongSelf.currentSpanIndex = mutableSpanIndex
+                        }
+                    } else {
+                        if strongSelf.setCurrentItem(newValue: item.key) {
+                            strongSelf.currentSpanIndex = mutableSpanIndex
+                        }
+                    }
+                    
+                    return
+                }
+                
+                lastItem = item.key
+            }
+        }
+    }
+}

--- a/Sources/Business Logic/SpanGridKeyboardNavigation.swift
+++ b/Sources/Business Logic/SpanGridKeyboardNavigation.swift
@@ -79,7 +79,7 @@ class SpanGridKeyboardNavigation<Content: View, Data: Identifiable & SpanGridSiz
                 return
             }
             
-            guard let newItem = strongSelf.getItem(forSpanIndex: mutableSpanIndex, grid: grid) else {
+            guard let newItem = grid.spanIndexCalculator.reverseLookup[mutableSpanIndex] else {
                 return
             }
             
@@ -90,7 +90,7 @@ class SpanGridKeyboardNavigation<Content: View, Data: Identifiable & SpanGridSiz
     }
     
     func isInvalidCell(spanIndex: Int, columnCount: Int, grid: SpanGrid<Content, Data>) -> Bool {
-        guard let item = getItem(forSpanIndex: spanIndex, grid: grid) else {
+        guard let item = grid.spanIndexCalculator.reverseLookup[spanIndex] else {
             return false
         }
         
@@ -110,31 +110,5 @@ class SpanGridKeyboardNavigation<Content: View, Data: Identifiable & SpanGridSiz
         }
         
         return false
-    }
-    
-    func getItem(forSpanIndex mutableSpanIndex: Int, grid: SpanGrid<Content, Data>) -> Int? {
-        if mutableSpanIndex < 0 {
-            return nil
-        }
-        
-        #warning("Optimisation: Cache a dictionary of spanIndex: itemIndex for the full range of data?")
-        let spanCache = grid.spanIndexCalculator.cache.sorted(by: { $0.key < $1.key })
-        var lastItem: Int?
-        
-        for item in spanCache {
-            if item.value >= mutableSpanIndex {
-                let diff = item.value - mutableSpanIndex
-                
-                if diff > 0 {
-                    return lastItem ?? item.key
-                } else {
-                    return item.key
-                }
-            }
-            
-            lastItem = item.key
-        }
-        
-        return nil
     }
 }

--- a/Sources/Business Logic/SpanGridSpanIndexCalculator.swift
+++ b/Sources/Business Logic/SpanGridSpanIndexCalculator.swift
@@ -44,7 +44,7 @@ internal class SpanGridSpanIndexCalculator<Content: View, Data: Identifiable & S
         let totalSpanIndex: Int = grid.data.reduce(0) { partialResult, gridData in
             // Populate any gaps in the reverse lookup cache.
             // This is appropriate where the last cell had a span of more than 1.
-            (lastPartial...partialResult).forEach {
+            (lastPartial ... partialResult).forEach {
                 reverseCache[$0] = lastCellIndex
             }
             

--- a/Sources/Business Logic/SpanGridSpanIndexCalculator.swift
+++ b/Sources/Business Logic/SpanGridSpanIndexCalculator.swift
@@ -10,7 +10,12 @@ internal class SpanGridSpanIndexCalculator<Content: View, Data: Identifiable & S
     var grid: SpanGrid<Content, Data>?
     
     var lastColumnCount: Int = -1
+    
+    // Maps cellIndex to spanIndex
     var cache: [Int: Int] = [:]
+    
+    // Maps spanIndex to cellIndex
+    var reverseLookup: [Int: Int] = [:]
     
     func precalculateSpanIndex(columnCount: Int) {
         guard cache.isEmpty || columnCount != lastColumnCount else {
@@ -29,13 +34,36 @@ internal class SpanGridSpanIndexCalculator<Content: View, Data: Identifiable & S
         var temporaryCache = [Int: Int]()
         temporaryCache.reserveCapacity(grid.data.count)
         
+        var reverseCache = [Int: Int]()
+        // reverseCache size will always be <= grid.data.count
+        reverseCache.reserveCapacity(grid.data.count)
+        
+        var lastPartial = 0
+        var lastCellIndex = 0
+        
         let totalSpanIndex: Int = grid.data.reduce(0) { partialResult, gridData in
+            // Populate any gaps in the reverse lookup cache.
+            // This is appropriate where the last cell had a span of more than 1.
+            (lastPartial...partialResult).forEach {
+                reverseCache[$0] = lastCellIndex
+            }
+            
+            // Set cache results for this cell
             temporaryCache[gridData.cellIndex] = partialResult
+            reverseCache[partialResult] = gridData.cellIndex
+            
+            // Store current position for next loop cycle
+            lastPartial = partialResult
+            lastCellIndex = gridData.cellIndex
+            
             return accumulateSpanIndex(partialResult: partialResult, gridData: gridData, columnCount: columnCount)
         }
         
         temporaryCache[grid.data.count] = totalSpanIndex
+        reverseCache[totalSpanIndex] = grid.data.count
+        
         cache = temporaryCache
+        reverseLookup = reverseCache
     }
     
     func accumulateSpanIndex(partialResult: Int, gridData: SpanGridData<Data>, columnCount: Int) -> Int {

--- a/Sources/Models/SpanGridCellMetadata.swift
+++ b/Sources/Models/SpanGridCellMetadata.swift
@@ -26,6 +26,11 @@ public struct SpanGridCellMetadata {
     
     /// The number of columns in the current layout.
     public let columnCount: Int
+    
+    /// Whether or not this cell is currently being highlighted by keyboard selection.
+    ///
+    /// This will always be `false` if you have keyboard selection disabled.
+    public let isHighlighted: Bool
 }
 
 public extension View {

--- a/Sources/Models/SpanGridColumnSizeStrategy.swift
+++ b/Sources/Models/SpanGridColumnSizeStrategy.swift
@@ -17,7 +17,7 @@ public enum SpanGridColumnSizeStrategy {
         count: Int = 3,
         configuration: SpanGridDynamicColumnSizeStrategy.Configuration = .init()
     ) -> SpanGridColumnSizeStrategy {
-        return .dynamic(count: count, configuration: configuration)
+        .dynamic(count: count, configuration: configuration)
     }
     
     var dynamicConfiguration: SpanGridDynamicColumnSizeStrategy.Configuration? {

--- a/Sources/Models/SpanGridKeyboardNavigationOptions.swift
+++ b/Sources/Models/SpanGridKeyboardNavigationOptions.swift
@@ -1,0 +1,45 @@
+//
+// SpanGridKeyboardNavigationOptions.swift
+//
+// Copyright 2021 • James Sherlock
+//
+
+import Foundation
+
+public struct SpanGridKeyboardNavigationOptions {
+    public struct Localization {
+        public let navigatePreviousRow: String
+        public let navigatePreviousItem: String
+        
+        public let navigateNextRow: String
+        public let navigateNextItem: String
+        
+        public init(navigatePreviousRow: String, navigatePreviousItem: String, navigateNextRow: String, navigateNextItem: String) {
+            self.navigatePreviousRow = navigatePreviousRow
+            self.navigatePreviousItem = navigatePreviousItem
+            self.navigateNextRow = navigateNextRow
+            self.navigateNextItem = navigateNextItem
+        }
+    }
+    
+    public let enabled: Bool
+    
+    public let discoverabilityEnabled: Bool
+    
+    public let localization: Localization
+    
+    public init(
+        enabled: Bool = false,
+        discoverabiliyEnabled: Bool = false,
+        localization: Localization? = nil
+    ) {
+        self.enabled = enabled
+        discoverabilityEnabled = discoverabiliyEnabled
+        self.localization = localization ?? .init(
+            navigatePreviousRow: "Navigate to previous row",
+            navigatePreviousItem: "Navigate to previous item",
+            navigateNextRow: "Navigate to next row",
+            navigateNextItem: "Navigate to next item"
+        )
+    }
+}

--- a/Sources/Models/SpanGridKeyboardNavigationOptions.swift
+++ b/Sources/Models/SpanGridKeyboardNavigationOptions.swift
@@ -4,17 +4,22 @@
 // Copyright 2021 • James Sherlock
 //
 
-import Foundation
+import SwiftUI
 
 public struct SpanGridKeyboardNavigationOptions {
     public struct Localization {
-        public let navigatePreviousRow: String
-        public let navigatePreviousItem: String
+        public let navigatePreviousRow: LocalizedStringKey
+        public let navigatePreviousItem: LocalizedStringKey
         
-        public let navigateNextRow: String
-        public let navigateNextItem: String
+        public let navigateNextRow: LocalizedStringKey
+        public let navigateNextItem: LocalizedStringKey
         
-        public init(navigatePreviousRow: String, navigatePreviousItem: String, navigateNextRow: String, navigateNextItem: String) {
+        public init(
+            navigatePreviousRow: LocalizedStringKey,
+            navigatePreviousItem: LocalizedStringKey,
+            navigateNextRow: LocalizedStringKey,
+            navigateNextItem: LocalizedStringKey
+        ) {
             self.navigatePreviousRow = navigatePreviousRow
             self.navigatePreviousItem = navigatePreviousItem
             self.navigateNextRow = navigateNextRow

--- a/Sources/Views/SpanGridKeyboardNavigationShortcuts.swift
+++ b/Sources/Views/SpanGridKeyboardNavigationShortcuts.swift
@@ -12,29 +12,57 @@ struct SpanGridKeyboardNavigationShortcuts: View {
         case down
         case left
         case right
+        
+        var shortcut: KeyEquivalent {
+            // There appears to be a bug on iPadOS where arrow keys are not valid inputs for keyboard shortcuts.
+            // As such, we currently use WASD.
+            //
+            // Sources:
+            // - https://www.reddit.com/r/SwiftUI/comments/lj1pj5/arrow_keys_in_swiftui_does_not_seem_to_work_on/
+            // - https://stackoverflow.com/questions/65584926/swiftui-keyboardshortcut-with-arrow-keys
+            // - My own testing (both Simulator and Physical Device)
+            switch self {
+            case .up: return "w"
+            case .left: return "a"
+            case .down: return "s"
+            case .right: return "d"
+            }
+        }
+        
+        func title(options: SpanGridKeyboardNavigationOptions) -> String {
+            switch self {
+            case .up: return options.localization.navigatePreviousRow
+            case .left: return options.localization.navigatePreviousItem
+            case .down: return options.localization.navigateNextRow
+            case .right: return options.localization.navigateNextItem
+            }
+        }
     }
     
-    let enabled: Bool
+    let options: SpanGridKeyboardNavigationOptions
     let callback: (Direction) -> Void
     
     var body: some View {
         VStack {
-            if enabled {
-                #warning("Feature: Could we hide the button labels from discoverability window? Or do we need to localize?")
-                #warning("Feature: Can we use arrow keys instead of WASD?")
-                
-                Button("Navigate up a row") { callback(.up) }
-                    .keyboardShortcut("w", modifiers: [])
-                
-                Button("Navigate down a row") { callback(.down) }
-                    .keyboardShortcut("s", modifiers: [])
-                
-                Button("Navigate to previous item") { callback(.left) }
-                    .keyboardShortcut("a", modifiers: [])
-                
-                Button("Navigate to next item") { callback(.right) }
-                    .keyboardShortcut("d", modifiers: [])
+            if options.enabled {
+                createButton(direction: .up)
+                createButton(direction: .left)
+                createButton(direction: .down)
+                createButton(direction: .right)
             }
+        }.hidden()
+    }
+    
+    @ViewBuilder func createButton(direction: Direction) -> some View {
+        if options.discoverabilityEnabled {
+            Button(direction.title(options: options)) { callback(direction) }
+                .keyboardShortcut(direction.shortcut, modifiers: [])
+        } else {
+            Button(
+                action: { callback(direction) },
+                label: { EmptyView() }
+            )
+            .keyboardShortcut(direction.shortcut, modifiers: [])
         }
     }
 }

--- a/Sources/Views/SpanGridKeyboardNavigationShortcuts.swift
+++ b/Sources/Views/SpanGridKeyboardNavigationShortcuts.swift
@@ -29,7 +29,7 @@ struct SpanGridKeyboardNavigationShortcuts: View {
             }
         }
         
-        func title(options: SpanGridKeyboardNavigationOptions) -> String {
+        func title(options: SpanGridKeyboardNavigationOptions) -> LocalizedStringKey {
             switch self {
             case .up: return options.localization.navigatePreviousRow
             case .left: return options.localization.navigatePreviousItem

--- a/Sources/Views/SpanGridKeyboardNavigationShortcuts.swift
+++ b/Sources/Views/SpanGridKeyboardNavigationShortcuts.swift
@@ -1,0 +1,37 @@
+//
+// SpanGridKeyboardNavigationShortcuts.swift
+//
+// Copyright 2021 • James Sherlock
+//
+
+import SwiftUI
+
+struct SpanGridKeyboardNavigationShortcuts: View {
+    enum Direction: CaseIterable {
+        case up
+        case down
+        case left
+        case right
+    }
+    
+    let enabled: Bool
+    let callback: (Direction) -> Void
+    
+    var body: some View {
+        VStack {
+            if enabled {
+                Button("Navigate up a row") { callback(.up) }
+                    .keyboardShortcut("w", modifiers: [])
+                
+                Button("Navigate down a row") { callback(.down) }
+                    .keyboardShortcut("s", modifiers: [])
+                
+                Button("Navigate to previous item") { callback(.left) }
+                    .keyboardShortcut("a", modifiers: [])
+                
+                Button("Navigate to next item") { callback(.right) }
+                    .keyboardShortcut("d", modifiers: [])
+            }
+        }
+    }
+}

--- a/Sources/Views/SpanGridKeyboardNavigationShortcuts.swift
+++ b/Sources/Views/SpanGridKeyboardNavigationShortcuts.swift
@@ -20,6 +20,9 @@ struct SpanGridKeyboardNavigationShortcuts: View {
     var body: some View {
         VStack {
             if enabled {
+                #warning("Feature: Could we hide the button labels from discoverability window? Or do we need to localize?")
+                #warning("Feature: Can we use arrow keys instead of WASD?")
+                
                 Button("Navigate up a row") { callback(.up) }
                     .keyboardShortcut("w", modifiers: [])
                 

--- a/Sources/Views/SpanGridWidthListener.swift
+++ b/Sources/Views/SpanGridWidthListener.swift
@@ -16,7 +16,8 @@ internal struct SpanGridWidthListener: UIViewControllerRepresentable {
             super.init(nibName: nil, bundle: nil)
         }
         
-        required init?(coder: NSCoder) {
+        @available(*, unavailable)
+        required init?(coder _: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
         

--- a/Tests/SpanGridKeyboardNavigationTests.swift
+++ b/Tests/SpanGridKeyboardNavigationTests.swift
@@ -251,7 +251,7 @@ class SpanGridKeyboardNavigationTests: XCTestCase {
         return SpanGrid(
             dataSource: data,
             columnSizeStrategy: .fixed(count: 3, width: 100, spacing: 0),
-            keyboardNavigationEnabled: true
+            keyboardNavigationOptions: .init(enabled: true)
         ) { _, _ in
             Rectangle()
         }.keyboardNavigationCoordinator
@@ -265,7 +265,7 @@ class SpanGridKeyboardNavigationTests: XCTestCase {
         return SpanGrid(
             dataSource: data,
             columnSizeStrategy: .fixed(count: 3, width: 100, spacing: 0),
-            keyboardNavigationEnabled: true
+            keyboardNavigationOptions: .init(enabled: true)
         ) { _, _ in
             Rectangle()
         }.keyboardNavigationCoordinator
@@ -279,7 +279,7 @@ class SpanGridKeyboardNavigationTests: XCTestCase {
         return SpanGrid(
             dataSource: data,
             columnSizeStrategy: .fixed(count: 4, width: 100, spacing: 0),
-            keyboardNavigationEnabled: true
+            keyboardNavigationOptions: .init(enabled: true)
         ) { _, _ in
             Rectangle()
         }.keyboardNavigationCoordinator

--- a/Tests/SpanGridKeyboardNavigationTests.swift
+++ b/Tests/SpanGridKeyboardNavigationTests.swift
@@ -280,7 +280,7 @@ class SpanGridKeyboardNavigationTests: XCTestCase {
             dataSource: data,
             columnSizeStrategy: .fixed(count: 4, width: 100, spacing: 0),
             keyboardNavigationEnabled: true
-        ) { viewModel, metadata in
+        ) { _, _ in
             Rectangle()
         }.keyboardNavigationCoordinator
     }

--- a/Tests/SpanGridKeyboardNavigationTests.swift
+++ b/Tests/SpanGridKeyboardNavigationTests.swift
@@ -140,7 +140,7 @@ class SpanGridKeyboardNavigationTests: XCTestCase {
         }
     }
     
-    func testNavigatingThroughWhitespaceSingle() {
+    func testNavigatingThroughWhitespace() {
         do { // vertical navigation
             let coordinator = createComplexKeyboardCoordinator()
             let process = coordinator.processDirection(3)
@@ -181,6 +181,49 @@ class SpanGridKeyboardNavigationTests: XCTestCase {
             XCTAssertEqual(coordinator.currentItem, 16)
             process(.left) // back to other side of whitespace
             XCTAssertEqual(coordinator.currentItem, 15)
+        }
+        
+        do { // mixed navigation
+            XCTExpectFailure {
+                let coordinator = createComplexKeyboardCoordinator()
+                let process = coordinator.processDirection(3)
+                
+                process(.down)
+                process(.down)
+                process(.down)
+                process(.down)
+                process(.down)
+                process(.down) // sixth row
+                XCTAssertEqual(coordinator.currentItem, 14)
+                process(.down) // seventh row (span:2 prefix:1)
+                XCTAssertEqual(coordinator.currentItem, 16)
+                process(.right)
+                XCTAssertEqual(coordinator.currentItem, 17)
+                process(.left)
+                XCTAssertEqual(coordinator.currentItem, 16)
+            }
+        }
+        
+        do { // mixed navigation
+            XCTExpectFailure {
+                let coordinator = createComplexKeyboardCoordinator()
+                let process = coordinator.processDirection(3)
+                
+                process(.down)
+                process(.down)
+                process(.down)
+                process(.down)
+                process(.down)
+                process(.down)
+                process(.right) // sixth row second item
+                XCTAssertEqual(coordinator.currentItem, 15)
+                process(.down) // seventh row (span:2 prefix:1)
+                XCTAssertEqual(coordinator.currentItem, 16)
+                process(.right)
+                XCTAssertEqual(coordinator.currentItem, 17)
+                process(.left)
+                XCTAssertEqual(coordinator.currentItem, 16)
+            }
         }
     }
     

--- a/Tests/SpanGridKeyboardNavigationTests.swift
+++ b/Tests/SpanGridKeyboardNavigationTests.swift
@@ -1,0 +1,282 @@
+//
+// SpanGridKeyboardNavigationTests.swift
+//
+// Copyright 2021 • James Sherlock
+//
+
+import SnapshotTesting
+@testable import SpanGrid
+import SwiftUI
+import UIKit
+import XCTest
+
+class SpanGridKeyboardNavigationTests: XCTestCase {
+    func testInitialControls() {
+        do { // On startup, currentItem is nil
+            let coordinator = createKeyboardCoordinator()
+            XCTAssertNil(coordinator.currentItem)
+        }
+        
+        do { // On directional event, currentItem goes to 0
+            SpanGridKeyboardNavigationShortcuts.Direction.allCases.forEach { direction in
+                let coordinator = createKeyboardCoordinator()
+                coordinator.processDirection(3)(direction)
+                XCTAssertEqual(coordinator.currentItem, 0)
+            }
+        }
+    }
+    
+    func testNavigationStraightDown() {
+        let coordinator = createKeyboardCoordinator()
+        let process = coordinator.processDirection(3)
+        
+        process(.down) // first row, first item
+        XCTAssertEqual(coordinator.currentItem, 0)
+        
+        process(.down) // second row, first item
+        XCTAssertEqual(coordinator.currentItem, 3)
+        
+        process(.down) // third row, first item (column span row)
+        XCTAssertEqual(coordinator.currentItem, 6)
+        
+        process(.down) // fourth row, first item
+        XCTAssertEqual(coordinator.currentItem, 7)
+        
+        process(.down) // fifth row, first item
+        XCTAssertEqual(coordinator.currentItem, 10)
+        
+        process(.down) // fifth row, first item (clamped)
+        XCTAssertEqual(coordinator.currentItem, 10)
+    }
+    
+    func testNavigationAroundRowSpan() {
+        let coordinator = createKeyboardCoordinator()
+        let process = coordinator.processDirection(3)
+        
+        process(.down)
+        process(.down)
+        process(.down)
+        XCTAssertEqual(coordinator.currentItem, 6)
+        
+        process(.left)
+        XCTAssertEqual(coordinator.currentItem, 5)
+        
+        process(.right)
+        XCTAssertEqual(coordinator.currentItem, 6)
+        
+        process(.right)
+        XCTAssertEqual(coordinator.currentItem, 7)
+    }
+    
+    func testNavigatingThroughRowSpanMaintainsColumn() {
+        do { // middle column
+            let coordinator = createKeyboardCoordinator()
+            let process = coordinator.processDirection(3)
+            
+            process(.down)
+            process(.down)
+            process(.right) // move into second column in second row
+            process(.down) // full row item (third row)
+            XCTAssertEqual(coordinator.currentItem, 6)
+            
+            process(.down) // fourth row, still second column
+            XCTAssertEqual(coordinator.currentItem, 8)
+        }
+        
+        do { // right column
+            let coordinator = createKeyboardCoordinator()
+            let process = coordinator.processDirection(3)
+            
+            process(.down)
+            process(.down)
+            process(.right) // move into second column in second row
+            process(.right) // move into third column in second row
+            process(.down) // full row item (third row)
+            XCTAssertEqual(coordinator.currentItem, 6)
+            
+            process(.down) // fourth row, still third olumn
+            XCTAssertEqual(coordinator.currentItem, 9)
+        }
+    }
+    
+    func testNavigatingThroughPartialColumnSpan() {
+        do { // left column
+            let coordinator = createComplexKeyboardCoordinator()
+            let process = coordinator.processDirection(3)
+            
+            process(.down)
+            process(.down)
+            process(.down)
+            XCTAssertEqual(coordinator.currentItem, 6)
+            process(.down)
+            XCTAssertEqual(coordinator.currentItem, 8)
+        }
+        
+        do { // middle column
+            let coordinator = createComplexKeyboardCoordinator()
+            let process = coordinator.processDirection(3)
+            
+            process(.down)
+            process(.down)
+            process(.right)
+            process(.down)
+            XCTAssertEqual(coordinator.currentItem, 6)
+            process(.down)
+            XCTAssertEqual(coordinator.currentItem, 9)
+        }
+        
+        do { // right column
+            let coordinator = createComplexKeyboardCoordinator()
+            let process = coordinator.processDirection(3)
+            
+            process(.down)
+            process(.down)
+            process(.right)
+            process(.right)
+            process(.down)
+            XCTAssertEqual(coordinator.currentItem, 7)
+            process(.down)
+            XCTAssertEqual(coordinator.currentItem, 10)
+        }
+    }
+    
+    func testNavigatingThroughWhitespace() {
+        do { // vertical navigation
+            XCTExpectFailure {
+                let coordinator = createComplexKeyboardCoordinator()
+                let process = coordinator.processDirection(3)
+                
+                process(.down)
+                process(.down)
+                process(.down)
+                process(.down)
+                process(.down) // fifth row
+                XCTAssertEqual(coordinator.currentItem, 11)
+                process(.right)
+                process(.right) // third column
+                XCTAssertEqual(coordinator.currentItem, 13)
+                process(.down) // through the whitespace
+                XCTAssertEqual(coordinator.currentItem, 17)
+                process(.up) // back up through the whitespace
+                XCTAssertEqual(coordinator.currentItem, 13)
+            }
+        }
+        
+        do { // horizontal navigation
+            XCTExpectFailure {
+                let coordinator = createComplexKeyboardCoordinator()
+                let process = coordinator.processDirection(3)
+                
+                process(.down)
+                process(.down)
+                process(.down)
+                process(.down)
+                process(.down)
+                process(.down) // sixth row
+                XCTAssertEqual(coordinator.currentItem, 14)
+                process(.right) // second column
+                XCTAssertEqual(coordinator.currentItem, 15)
+                process(.right) // into whitespace (expect to wrap)
+                XCTAssertEqual(coordinator.currentItem, 16)
+                process(.right) // to next item (col span 2)
+                XCTAssertEqual(coordinator.currentItem, 17)
+                process(.left) // back to col span 2
+                XCTAssertEqual(coordinator.currentItem, 16)
+                process(.left) // back to other side of whitespace
+                XCTAssertEqual(coordinator.currentItem, 15)
+            }
+        }
+    }
+    
+    func testOutOfBounds() {
+        let coordinator = createKeyboardCoordinator()
+        let process = coordinator.processDirection(3)
+        
+        process(.left)
+        XCTAssertEqual(coordinator.currentItem, 0) // default
+        
+        process(.left)
+        XCTAssertEqual(coordinator.currentItem, 0) // out of bounds left
+        
+        process(.up)
+        XCTAssertEqual(coordinator.currentItem, 0) // out of bounds up
+        
+        process(.right)
+        XCTAssertEqual(coordinator.currentItem, 1)
+        process(.up)
+        XCTAssertEqual(coordinator.currentItem, 1) // out of bounds up
+        
+        process(.down)
+        process(.down)
+        process(.down)
+        XCTAssertEqual(coordinator.currentItem, 8)
+        process(.down)
+        XCTAssertEqual(coordinator.currentItem, 11)
+        process(.down)
+        XCTAssertEqual(coordinator.currentItem, 11) // out of bounds down
+        process(.right)
+        process(.down)
+        XCTAssertEqual(coordinator.currentItem, 12) // out of bounds down
+        process(.right)
+        XCTAssertEqual(coordinator.currentItem, 12) // out of bounds right
+    }
+    
+    func testMonkeyNavigationAndPerformance() {
+        let options = XCTMeasureOptions()
+        options.iterationCount = 2
+        options.invocationOptions = [ .manuallyStart, .manuallyStop ]
+        
+        measure(
+            metrics: [
+                XCTClockMetric(),
+            ],
+            options: options
+        ) {
+            // Sitting at around 2.2s
+            let coordinator = createKeyboardCoordinator(size: 100)
+            coordinator.grid?.spanIndexCalculator.precalculateSpanIndex(columnCount: 3)
+            let process = coordinator.processDirection(3)
+            
+            startMeasuring()
+            
+            for _ in 0 ..< 5000 {
+                process(SpanGridKeyboardNavigationShortcuts.Direction.allCases.randomElement()!)
+            }
+            
+            stopMeasuring()
+        }
+    }
+    
+    func createKeyboardCoordinator(size: Int = 13) -> SpanGridKeyboardNavigation<Rectangle, ViewModel> {
+        let data = (0 ..< size).map { offset -> ViewModel in
+            ViewModel(id: offset, layoutSize: offset == 6 ? .row : .cell)
+        }
+        
+        return SpanGrid(
+            dataSource: data,
+            columnSizeStrategy: .fixed(count: 3, width: 100, spacing: 0),
+            keyboardNavigationEnabled: true
+        ) { _, _ in
+            Rectangle()
+        }.keyboardNavigationCoordinator
+    }
+    
+    func createComplexKeyboardCoordinator() -> SpanGridKeyboardNavigation<Rectangle, ViewModel> {
+        let data = (0 ..< 21).map { offset -> ViewModel in
+            ViewModel(id: offset, layoutSize: offset == 6 || offset == 16 ? .span(2) : .cell)
+        }
+        
+        return SpanGrid(
+            dataSource: data,
+            columnSizeStrategy: .fixed(count: 3, width: 100, spacing: 0),
+            keyboardNavigationEnabled: true
+        ) { _, _ in
+            Rectangle()
+        }.keyboardNavigationCoordinator
+    }
+    
+    struct ViewModel: Identifiable, SpanGridSizeInfoProvider {
+        let id: Int
+        let layoutSize: SpanGridLayoutSize
+    }
+}

--- a/Tests/SpanGridKeyboardNavigationTests.swift
+++ b/Tests/SpanGridKeyboardNavigationTests.swift
@@ -228,7 +228,7 @@ class SpanGridKeyboardNavigationTests: XCTestCase {
             ],
             options: options
         ) {
-            // 🚨 Was 2.2s, now 3.154s after keyboard navigation work (isInvalidCell)
+            // Sitting at around 0.135s
             let coordinator = createKeyboardCoordinator(size: 100)
             coordinator.grid?.spanIndexCalculator.precalculateSpanIndex(columnCount: 3)
             let process = coordinator.processDirection(3)
@@ -267,6 +267,20 @@ class SpanGridKeyboardNavigationTests: XCTestCase {
             columnSizeStrategy: .fixed(count: 3, width: 100, spacing: 0),
             keyboardNavigationEnabled: true
         ) { _, _ in
+            Rectangle()
+        }.keyboardNavigationCoordinator
+    }
+    
+    func createComplexKeyboardCoordinator_FourColumn() -> SpanGridKeyboardNavigation<Rectangle, ViewModel> {
+        let data = (0 ..< 30).map { offset -> ViewModel in
+            ViewModel(id: offset, layoutSize: offset == 6 || offset == 19 ? .span(offset == 6 ? 3 : 2) : .cell)
+        }
+        
+        return SpanGrid(
+            dataSource: data,
+            columnSizeStrategy: .fixed(count: 4, width: 100, spacing: 0),
+            keyboardNavigationEnabled: true
+        ) { viewModel, metadata in
             Rectangle()
         }.keyboardNavigationCoordinator
     }

--- a/Tests/SpanGridKeyboardNavigationTests.swift
+++ b/Tests/SpanGridKeyboardNavigationTests.swift
@@ -140,26 +140,24 @@ class SpanGridKeyboardNavigationTests: XCTestCase {
         }
     }
     
-    func testNavigatingThroughWhitespace() {
+    func testNavigatingThroughWhitespaceSingle() {
         do { // vertical navigation
-            XCTExpectFailure {
-                let coordinator = createComplexKeyboardCoordinator()
-                let process = coordinator.processDirection(3)
-                
-                process(.down)
-                process(.down)
-                process(.down)
-                process(.down)
-                process(.down) // fifth row
-                XCTAssertEqual(coordinator.currentItem, 11)
-                process(.right)
-                process(.right) // third column
-                XCTAssertEqual(coordinator.currentItem, 13)
-                process(.down) // through the whitespace
-                XCTAssertEqual(coordinator.currentItem, 17)
-                process(.up) // back up through the whitespace
-                XCTAssertEqual(coordinator.currentItem, 13)
-            }
+            let coordinator = createComplexKeyboardCoordinator()
+            let process = coordinator.processDirection(3)
+            
+            process(.down)
+            process(.down)
+            process(.down)
+            process(.down)
+            process(.down) // fifth row
+            XCTAssertEqual(coordinator.currentItem, 11)
+            process(.right)
+            process(.right) // third column
+            XCTAssertEqual(coordinator.currentItem, 13)
+            process(.down) // through the whitespace
+            XCTAssertEqual(coordinator.currentItem, 17)
+            process(.up) // back up through the whitespace
+            XCTAssertEqual(coordinator.currentItem, 13)
         }
         
         do { // horizontal navigation
@@ -230,7 +228,7 @@ class SpanGridKeyboardNavigationTests: XCTestCase {
             ],
             options: options
         ) {
-            // Sitting at around 2.2s
+            // 🚨 Was 2.2s, now 3.154s after keyboard navigation work (isInvalidCell)
             let coordinator = createKeyboardCoordinator(size: 100)
             coordinator.grid?.spanIndexCalculator.precalculateSpanIndex(columnCount: 3)
             let process = coordinator.processDirection(3)

--- a/Tests/SpanGridKeyboardNavigationTests.swift
+++ b/Tests/SpanGridKeyboardNavigationTests.swift
@@ -163,28 +163,26 @@ class SpanGridKeyboardNavigationTests: XCTestCase {
         }
         
         do { // horizontal navigation
-            XCTExpectFailure {
-                let coordinator = createComplexKeyboardCoordinator()
-                let process = coordinator.processDirection(3)
-                
-                process(.down)
-                process(.down)
-                process(.down)
-                process(.down)
-                process(.down)
-                process(.down) // sixth row
-                XCTAssertEqual(coordinator.currentItem, 14)
-                process(.right) // second column
-                XCTAssertEqual(coordinator.currentItem, 15)
-                process(.right) // into whitespace (expect to wrap)
-                XCTAssertEqual(coordinator.currentItem, 16)
-                process(.right) // to next item (col span 2)
-                XCTAssertEqual(coordinator.currentItem, 17)
-                process(.left) // back to col span 2
-                XCTAssertEqual(coordinator.currentItem, 16)
-                process(.left) // back to other side of whitespace
-                XCTAssertEqual(coordinator.currentItem, 15)
-            }
+            let coordinator = createComplexKeyboardCoordinator()
+            let process = coordinator.processDirection(3)
+            
+            process(.down)
+            process(.down)
+            process(.down)
+            process(.down)
+            process(.down)
+            process(.down) // sixth row
+            XCTAssertEqual(coordinator.currentItem, 14)
+            process(.right) // second column
+            XCTAssertEqual(coordinator.currentItem, 15)
+            process(.right) // into whitespace (expect to wrap)
+            XCTAssertEqual(coordinator.currentItem, 16)
+            process(.right) // to next item (col span 2)
+            XCTAssertEqual(coordinator.currentItem, 17)
+            process(.left) // back to col span 2
+            XCTAssertEqual(coordinator.currentItem, 16)
+            process(.left) // back to other side of whitespace
+            XCTAssertEqual(coordinator.currentItem, 15)
         }
     }
     

--- a/Tests/SpanGridKeyboardNavigationTests.swift
+++ b/Tests/SpanGridKeyboardNavigationTests.swift
@@ -184,46 +184,42 @@ class SpanGridKeyboardNavigationTests: XCTestCase {
         }
         
         do { // mixed navigation
-            XCTExpectFailure {
-                let coordinator = createComplexKeyboardCoordinator()
-                let process = coordinator.processDirection(3)
-                
-                process(.down)
-                process(.down)
-                process(.down)
-                process(.down)
-                process(.down)
-                process(.down) // sixth row
-                XCTAssertEqual(coordinator.currentItem, 14)
-                process(.down) // seventh row (span:2 prefix:1)
-                XCTAssertEqual(coordinator.currentItem, 16)
-                process(.right)
-                XCTAssertEqual(coordinator.currentItem, 17)
-                process(.left)
-                XCTAssertEqual(coordinator.currentItem, 16)
-            }
+            let coordinator = createComplexKeyboardCoordinator()
+            let process = coordinator.processDirection(3)
+            
+            process(.down)
+            process(.down)
+            process(.down)
+            process(.down)
+            process(.down)
+            process(.down) // sixth row
+            XCTAssertEqual(coordinator.currentItem, 14)
+            process(.down) // seventh row (span:2 prefix:1)
+            XCTAssertEqual(coordinator.currentItem, 16)
+            process(.right)
+            XCTAssertEqual(coordinator.currentItem, 17)
+            process(.left)
+            XCTAssertEqual(coordinator.currentItem, 16)
         }
         
         do { // mixed navigation
-            XCTExpectFailure {
-                let coordinator = createComplexKeyboardCoordinator()
-                let process = coordinator.processDirection(3)
-                
-                process(.down)
-                process(.down)
-                process(.down)
-                process(.down)
-                process(.down)
-                process(.down)
-                process(.right) // sixth row second item
-                XCTAssertEqual(coordinator.currentItem, 15)
-                process(.down) // seventh row (span:2 prefix:1)
-                XCTAssertEqual(coordinator.currentItem, 16)
-                process(.right)
-                XCTAssertEqual(coordinator.currentItem, 17)
-                process(.left)
-                XCTAssertEqual(coordinator.currentItem, 16)
-            }
+            let coordinator = createComplexKeyboardCoordinator()
+            let process = coordinator.processDirection(3)
+            
+            process(.down)
+            process(.down)
+            process(.down)
+            process(.down)
+            process(.down)
+            process(.down)
+            process(.right) // sixth row second item
+            XCTAssertEqual(coordinator.currentItem, 15)
+            process(.down) // seventh row (span:2 prefix:1)
+            XCTAssertEqual(coordinator.currentItem, 16)
+            process(.right)
+            XCTAssertEqual(coordinator.currentItem, 17)
+            process(.left)
+            XCTAssertEqual(coordinator.currentItem, 16)
         }
     }
     


### PR DESCRIPTION
Started testing this with a local project and it works fairly well. The biggest issue currently is that it really struggles around whitespace so we need to handle cell prefix in the maths calculations.

There also appears to be a fairly big performance penalty when dealing with large data sets in monkey mode. The numbers don't scare me since this is a manual user input which itself has time to register, but it would be nice to investigate some basic optimisations around that.

Finally, I'm trying to wrap my head around how keyboard navigation would work for cells with nested content. I'm thinking about the App Store layout where a cell can itself be another horizontal scrolling grid (a carousel). 

How should keyboard navigation work with this? How can we add support for it? Could we make our solution more generic so it could be accessed by the public interface? We need to setup an example demonstrating this.

Arrow key navigation was not working on simulator, unsure why. Need to try on a physical device to see if there's a SwiftUI limitation there. Also, if we can't disable discoverability then we need to allow developers to pass through localised strings.

Video demonstrating behaviour: https://user-images.githubusercontent.com/15193942/135714274-6af1a55b-14e2-4ce3-b386-2f76302360d4.mov

# TODO

- [x] 🚨  ~~Should use arrow keys instead of WASD~~ Not possible due to Apple limitation
- [x] Should disable discoverability, or allow user to localise
- [x] Fix issue with navigation around whitespace (cell prefix)
- [x] Fix performance with constantly looping over full cell cache
- [x] ⚠️  ~~Allow user to have cells opt out of keyboard navigation (would skip, similar to whitespace)~~ Out of scope for MVP
- [x] Hide the keyboard input buttons
- [x] Update documentation